### PR TITLE
add bluesky support

### DIFF
--- a/core/src/main/resources/bundled.json
+++ b/core/src/main/resources/bundled.json
@@ -30,6 +30,12 @@
       "pattern": "^(\\/.*)$",
       "ignore_pattern": "^(\\/api\\/info.*)$",
       "embed_domains": ["phixiv.net"]
+    },
+    {
+      "name": "Bluesky",
+      "domain": "bsky.app",
+      "pattern": "^(\\/profile\\/((([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9]))|did:plc:\\w+)\\/post\\/\\w+).*$",
+      "embed_domains": ["boobsky.app"]
     }
   ]
 }

--- a/core/src/main/resources/bundled.json
+++ b/core/src/main/resources/bundled.json
@@ -35,7 +35,7 @@
       "name": "Bluesky",
       "domain": "bsky.app",
       "pattern": "^(\\/profile\\/((([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9]))|did:plc:\\w+)\\/post\\/\\w+).*$",
-      "embed_domains": ["boobsky.app"]
+      "embed_domains": ["boobsky.app", "bsyy.app", "bskyx.app", "fxbsky.app"]
     }
   ]
 }


### PR DESCRIPTION
adds bluesky support to embed resolving.
part of the regex for matching handles was taken from [the atproto docs](https://atproto.com/specs/handle)